### PR TITLE
I've recorded my findings from the build and test execution attempts.

### DIFF
--- a/memory-bank/android-sdk-not-found-issue.md
+++ b/memory-bank/android-sdk-not-found-issue.md
@@ -1,0 +1,49 @@
+# Android SDK Not Found: Preventing Unit Test Execution
+
+## Task Attempted
+
+The goal was to run the debug unit tests for the Android project using the Gradle command:
+`./gradlew testDebugUnitTest --stacktrace`
+
+## Error Encountered
+
+The build consistently failed with the following error message:
+
+```
+Could not determine the dependencies of task ':app:testDebugUnitTest'.
+> SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file at '/app/local.properties'.
+```
+
+This error indicates that Gradle could not find the Android SDK, which is essential for compiling and running tests that depend on Android libraries and resources (commonly, Robolectric tests or other unit tests that interact with Android framework classes).
+
+## Troubleshooting Steps Taken
+
+Several steps were taken to try and resolve this issue within the sandbox environment:
+
+1.  **Verified `JAVA_HOME`**: Ensured `JAVA_HOME` was correctly set to `/usr/lib/jvm/java-21-openjdk-amd64`. This had previously resolved issues with other Gradle tasks (like `./gradlew tasks`) that depended on a valid JDK.
+2.  **Searched for Android SDK**:
+    *   Checked several common installation paths for the Android SDK (e.g., `/opt/android/sdk`, `/usr/local/android/sdk`, `/android_sdk`, `/sdk`, `/usr/lib/android-sdk`) using `ls`. None of these paths existed.
+    *   Used `find / -name "platform-tools" -type d 2>/dev/null` and `find / -name "platforms" -type d 2>/dev/null` to search for characteristic subdirectories of an Android SDK. These searches did not yield any relevant SDK locations.
+3.  **Configured `local.properties`**: As suggested by the error message, a `local.properties` file was created in the project root (`/app/local.properties`) with the following content:
+    ```properties
+    sdk.dir=/opt/android/sdk
+    ```
+    This was an attempt to point Gradle to a conventional SDK path, in case it was present but not configured via an environment variable.
+4.  **Re-ran Tests**: After each significant troubleshooting step (like setting `JAVA_HOME` or creating `local.properties`), the `./gradlew testDebugUnitTest` command was re-executed.
+
+## Conclusion for Sandbox Environment
+
+Despite these efforts, the "SDK location not found" error persisted. This strongly indicates that the **Android SDK is not installed or available in the current sandbox environment.** Without the Android SDK, unit tests that rely on Android framework components (such as those typically run by `testDebugUnitTest`) cannot be executed.
+
+## Resolution in a Local/Standard Environment
+
+In a local development environment, this issue would typically be resolved by:
+
+1.  **Installing the Android SDK**: Downloading and installing the Android SDK from the official Android developer website. This usually involves installing Android Studio, which includes an SDK Manager, or using the command-line SDK tools.
+2.  **Setting `ANDROID_HOME`**: Defining the `ANDROID_HOME` environment variable to point to the root directory of the installed Android SDK.
+    *   Example (Linux/macOS): `export ANDROID_HOME="/path/to/your/android/sdk"`
+    *   Example (Windows): `set ANDROID_HOME=C:\path\to\your\android\sdk`
+3.  **Alternatively, configuring `local.properties`**: Ensuring the `local.properties` file in the Android project root contains the correct path to the SDK:
+    `sdk.dir=/path/to/your/android/sdk` (use backslashes `\` for Windows paths if necessary, e.g., `sdk.dir=C:\\Users\\YourUser\\AppData\\Local\\Android\\Sdk`)
+
+Once the SDK is correctly installed and its location is known to Gradle (either via `ANDROID_HOME` or `local.properties`), the unit tests should be able to resolve Android dependencies and execute.

--- a/memory-bank/jdk-transform-issue-resolution.md
+++ b/memory-bank/jdk-transform-issue-resolution.md
@@ -1,0 +1,25 @@
+# Resolving JdkImageTransform and jlink.exe Errors in Gradle
+
+## Original Error
+
+When attempting to run Gradle tasks, the build failed with errors related to `JdkImageTransform` and the inability to find or execute `jlink.exe`. This typically indicates an issue with the Java Development Kit (JDK) configuration being used by Gradle, where it cannot locate or properly utilize the `jlink` tool, which is essential for creating custom Java runtime images.
+
+## Successful Resolution Steps
+
+The issue was resolved by ensuring that the `JAVA_HOME` environment variable was set to a valid and appropriate JDK path for the build environment.
+
+1.  **Initial Attempts:** An initial attempt to set `JAVA_HOME` to a Windows-style path (`C:\Program Files\Android\Android Studio\jbr`) failed in the Linux-based sandbox environment because the path format was incorrect.
+2.  **Identifying Available JDKs:** The command `ls /usr/lib/jvm` was used to list available JDK installations within the sandbox.
+3.  **Setting `JAVA_HOME`:** Based on the output, `JAVA_HOME` was set to `/usr/lib/jvm/java-21-openjdk-amd64`.
+    ```bash
+    export JAVA_HOME="/usr/lib/jvm/java-21-openjdk-amd64"
+    ```
+4.  **Verification:** The Gradle command `./gradlew tasks --stacktrace --info --warning-mode all` was executed again.
+
+## Outcome
+
+After setting `JAVA_HOME` to `/usr/lib/jvm/java-21-openjdk-amd64`, the `./gradlew tasks` command completed successfully. The `JdkImageTransform` and `jlink.exe` errors were no longer present in the build output.
+
+## Important Note
+
+During the successful Gradle execution, numerous "Resource missing" errors were observed (e.g., `Resource missing. [HTTP GET: https://dl.google.com/dl/android/maven2/... ]`). These errors are likely due to the sandbox environment having limited or no internet access to download dependencies from repositories like Google Maven or Maven Central. However, for the `tasks` command (which primarily lists available tasks rather than compiling the full application), these missing dependencies did not hinder Gradle's initialization or the successful completion of the command itself. The core `jlink.exe` issue was resolved by the correct `JAVA_HOME` setting.


### PR DESCRIPTION
- I documented the resolution of the JdkImageTransform/jlink.exe error by setting JAVA_HOME correctly.
- I also documented the subsequent issue where unit tests (Robolectric) could not be run due to the Android SDK not being found in the environment.

No code changes were made to test files as test execution was blocked.